### PR TITLE
Update preload.js

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -13,7 +13,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
         }
 
         return new Promise((resolve, reject) => {
-            let ffmpegProcess = spawn(ffmpeg, ['-i', inputVideoPath, outputVideoPath]);
+            let ffmpegProcess = spawn(ffmpeg, ['-i', inputVideoPath, "-c:v libx264", outputVideoPath]);
 
             ffmpegProcess.stderr.on('data', (data) => {
                 let output = data.toString();


### PR DESCRIPTION
# 修复16行编码问题，html5中video要求为h264编码的MP4